### PR TITLE
Add redux

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Dan Ryan <github:@dryan>
 Grant Stromgren <github:@phpsmith>
+HANA <github:@haworku>

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,2 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
-
-// You can delete this file if you're not using it
+import wrapWithReduxProvider from "./wrap-with-redux-provider"
+export const wrapRootElement = wrapWithReduxProvider

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,2 @@
-/**
- * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/ssr-apis/
- */
-
-// You can delete this file if you're not using it
+import wrapWithReduxProvider from "./wrap-with-redux-provider"
+export const wrapRootElement = wrapWithReduxProvider

--- a/package-lock.json
+++ b/package-lock.json
@@ -12050,6 +12050,19 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-redux": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.0.tgz",
+      "integrity": "sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
+      }
+    },
     "react-side-effect": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^5.2.1",
+    "react-redux": "^7.1.0"
   },
   "devDependencies": {
     "prettier": "^1.18.2"

--- a/src/components/Welcome.js
+++ b/src/components/Welcome.js
@@ -1,0 +1,38 @@
+import React, { Component } from "react"
+
+import { connect } from "react-redux"
+
+const mapStateToProps = ({ hasAcknowledged }) => {
+  return { hasAcknowledged }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    acknowledge: bool => dispatch({ type: `UPDATE ACKNOWLEDGEMENT` }),
+  }
+}
+
+class Welcome extends Component {
+  state = {}
+  render() {
+    return (
+      <div style={{ margin: "1rem", padding: "1rem" }}>
+        <h2>Welcome to the new FreeFrom Quiz.</h2>
+        <div>
+          <label htmlFor="Acknowledgement checkbox">
+            <input type="checkbox" onChange={this.props.acknowledge} />
+          </label>
+          <span>
+            By checking this box, you acknowledge that you have read and agree
+            to the terms and conditions provided.
+          </span>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Welcome)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,17 +2,15 @@ import React from "react"
 import { Link } from "gatsby"
 
 import Layout from "../components/layout"
+import Welcome from "../components/Welcome"
 import SEO from "../components/seo"
 
 const IndexPage = () => (
   <Layout>
     <SEO title="Home" />
-    <h1>FreeFrom Front End</h1>
-    <p>Welcome to the new FreeFrom Quiz</p>
-    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-
-    </div>
+    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}></div>
     <Link to="/page-2/">Go to page 2</Link>
+    <Welcome />
   </Layout>
 )
 

--- a/src/state/reducers.js
+++ b/src/state/reducers.js
@@ -1,0 +1,11 @@
+// As state gets more complicated, we may have multiple reducers and need to use `combineReducers`
+const rootReducer = (state, action) => {
+  if (action.type === `UPDATE ACKNOWLEDGEMENT`) {
+    return Object.assign({}, state, {
+      hasAcknowledged: !state.hasAcknowledged,
+    })
+  }
+  return state
+}
+
+export { rootReducer }

--- a/src/state/reduxInitialize.js
+++ b/src/state/reduxInitialize.js
@@ -1,0 +1,8 @@
+import { createStore as reduxCreateStore } from "redux"
+import { rootReducer } from "./reducers"
+
+const initialState = { hasAcknowledged: false }
+
+const createStore = () => reduxCreateStore(rootReducer, initialState)
+
+export default createStore

--- a/src/state/reduxInitialize.js
+++ b/src/state/reduxInitialize.js
@@ -1,8 +1,15 @@
-import { createStore as reduxCreateStore } from "redux"
+import { compose, createStore as reduxCreateStore } from "redux"
 import { rootReducer } from "./reducers"
 
 const initialState = { hasAcknowledged: false }
+const useDevTools =
+  process.env.NODE_ENV === "development" &&
+  typeof window !== "undefined" &&
+  window.devToolsExtension
 
-const createStore = () => reduxCreateStore(rootReducer, initialState)
+const middleware = compose(useDevTools ? window.devToolsExtension() : f => f)
+
+const createStore = () =>
+  reduxCreateStore(rootReducer, initialState, middleware)
 
 export default createStore

--- a/wrap-with-redux-provider.js
+++ b/wrap-with-redux-provider.js
@@ -1,0 +1,11 @@
+import React from "react"
+import { Provider } from "react-redux"
+
+import createStore from "./src/state/reduxInitialize"
+
+export default ({ element }) => {
+  // Following the model from https://github.com/gatsbyjs/gatsby/tree/master/examples/using-redux
+  // instantiating store in a wrapped element ensures there is fresh store for each SSR page
+  const store = createStore()
+  return <Provider store={store}>{element}</Provider>
+}


### PR DESCRIPTION
Add redux for state management (`react-redux` package and also support for redux dev tools). Add example connected `Welcome.js` component. Follows approach from [Gatsby docs](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-redux). Resolves #7 