### PR TITLE
Update eslint-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5217,9 +5217,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",


### PR DESCRIPTION
https://www.npmjs.com/advisories/1118

>Overview
Versions of eslint-utils >=1.2.0 or <1.4.1 are vulnerable to Arbitrary Code Execution. The getStaticValue does not properly sanitize user input allowing attackers to supply malicious input that executes arbitrary code during the linting process. The getStringIfConstant and getPropertyName functions are not affected.

>Remediation
Upgrade to version 1.4.1 or later.