### PR TITLE
Make Exit Site MaterialLink use href

### DIFF
--- a/src/components/layout/Navbar.js
+++ b/src/components/layout/Navbar.js
@@ -137,8 +137,7 @@ const Navbar = ({ auth: { isAuthenticated, loading }, logout }) => {
     <MaterialLink
       className={classes.link}
       underline="hover"
-      component="button"
-      onClick={() => document.location.replace("https://www.weather.com")}
+      href="https://www.weather.com"
     >
       Exit Site
     </MaterialLink>


### PR DESCRIPTION
Exit Site was a button using document.location.replace.
document.location.replace does not add the departed page to the browser
history, leading to confusing browser history navigation.
This commit changes the Exit Site link from a button to an anchor.

Close #49 

To test, click the Exit Site link and then go back in the browser history.
You should be back to the page you were on before you clicked Exit Site.