### PR TITLE
Add open graph type

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
     />
     <meta property="og:url" content="https://compass.freefrom.org" />
     <meta property="og:image" content="https://compass.freefrom.org/images/general/opengraph.png" />
+    <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <!-- <link rel="apple-touch-icon" href="logo192.png" /> -->
     <!--


### PR DESCRIPTION
https://ogp.me/ states that the four required OG tags are title, type, image, and URL. Title, image, and URL are already in index.html. This PR adds type.