### PR TITLE
Style landing page

### DIFF
--- a/public/assets/css/custom.css
+++ b/public/assets/css/custom.css
@@ -9,7 +9,7 @@ li p {
     margin-block-end: 0;
 }
 
-.MuiTypography-root a {
+a {
     color: #2675D3;
     font-weight: 500;
 }

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -56,13 +56,15 @@ const Home = ({ isAuthenticated, quiz, setAgreement, setCookies }) => {
         </Typography>
       </Box>
       <Box mb={2}>
-        <MaterialLink
-          color="inherit"
-          component={Link}
-          to="/terms-and-conditions"
-        >
-          Full Terms & Conditions
-        </MaterialLink>
+        <Typography variant="body1">
+          <MaterialLink
+            color="inherit"
+            component={Link}
+            to="/terms-and-conditions"
+          >
+            Full Terms & Conditions
+          </MaterialLink>
+        </Typography>
       </Box>
       <Box mb={2}>
         <FormGroup row>


### PR DESCRIPTION
close #99 

- Reduce the specificity of the CSS rule that makes links blue so that ".makeStyles-link-271" has priority over it and the "Learn more" text becomes teal
- Change "Full Terms & Conditions" font size to 16

I've tested by going through the quiz and checking that every other link stayed blue other than "Learn more"