### PR TITLE
"Add our email to your address book" copy on Next Steps > Success

### DIFF
--- a/src/components/pages/NextStepsSuccess.js
+++ b/src/components/pages/NextStepsSuccess.js
@@ -36,6 +36,16 @@ const useStyles = makeStyles(theme => ({
       flexDirection: "row",
     },
   },
+  titleBox: {
+    [theme.breakpoints.down('sm')]: {
+      paddingLeft: 10,
+      paddingRight: 10,
+    },
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: 0,
+      paddingRight: 0,
+    }
+  },
   actionButton: {
     marginBottom: 0,
     [theme.breakpoints.down('sm')]: {
@@ -65,20 +75,25 @@ const NextStepsSuccess = ({ quiz }) => {
   return (
     <Container maxWidth="md">
       <Title />
-      <Box mb={2}>
-        <Typography variant="h1">You're All Set!</Typography>
-      </Box>
-      <Box mb={4}>
-        <Typography variant="body1">
-          Make sure to add compass@freefrom.org to your address book so you receive our emails.
-          If you don't see an email from us in the next day, please check your Spam folder.
-        </Typography>
+      <Box className={classes.titleBox}>
+        <Box mb={2}>
+          <Typography variant="h1">You're All Set!</Typography>
+        </Box>
+        <Box mb={4}>
+          <Typography variant="body1">
+            Make sure to add compass@freefrom.org to your address book so you receive our emails.
+            If you don't see an email from us in the next day, please check your Spam folder.
+          </Typography>
+        </Box>
       </Box>
 
       <Divider light={true} />
 
       <Box className={classes.buttonBox} display="flex" alignItems="flex-start" justifyContent="space-between" paddingBottom={4} paddingTop={4} >
         <Box maxWidth={500}>
+          <Box mb={2}>
+            <Typography variant="h2">Help us improve this tool</Typography>
+          </Box>
           <Typography variant="body1">
             We have a few quick questions about how we can
             improve this tool. Sharing your feedback will take less than one
@@ -101,6 +116,9 @@ const NextStepsSuccess = ({ quiz }) => {
 
       <Box className={classes.buttonBox} display="flex" alignItems="flex-start" justifyContent="space-between" paddingTop={4} paddingBottom={4}>
         <Box maxWidth={500}>
+          <Box mb={2}>
+            <Typography variant="h2">Support FreeFrom</Typography>
+          </Box>
           <Typography variant="body1">
             Want to help us help other survivors?  Give $1, $3, or $5 so that we
             can continue to improve the Compensation Compass and help survivors
@@ -108,7 +126,7 @@ const NextStepsSuccess = ({ quiz }) => {
           </Typography>
         </Box>
 
-        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank" rel="noopener noreferrer">
           <input type="hidden" name="cmd" value="_s-xclick" />
           <input type="hidden" name="hosted_button_id" value="PC66QVXYX42RQ" />
           <Button
@@ -116,8 +134,6 @@ const NextStepsSuccess = ({ quiz }) => {
             color="primary"
             variant="contained"
             type="submit"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             Make a Contribution
           </Button>

--- a/src/components/pages/NextStepsSuccess.js
+++ b/src/components/pages/NextStepsSuccess.js
@@ -67,9 +67,9 @@ const useStyles = makeStyles(theme => ({
 const NextStepsSuccess = ({ quiz }) => {
   const classes = useStyles();
 
-  // if (!quiz.agreement) {
-  //   return <Redirect to="/" />
-  // }
+  if (!quiz.agreement) {
+    return <Redirect to="/" />
+  }
 
   return (
     <Container maxWidth="md">
@@ -140,7 +140,7 @@ const NextStepsSuccess = ({ quiz }) => {
               color="primary"
               variant="outlined"
               component={Link}
-              // to={`/mindsets/${quiz.mindset.slug}/${quiz.location}`}
+              to={`/mindsets/${quiz.mindset.slug}/${quiz.location}`}
               onClick={scrollToTop}
             >
               Back To Results

--- a/src/components/pages/NextStepsSuccess.js
+++ b/src/components/pages/NextStepsSuccess.js
@@ -35,9 +35,6 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('md')]: {
       flexDirection: "row",
     },
-    [theme.breakpoints.up('lg')]: {
-      flexDirection: "row",
-    },
   },
   actionButton: {
     marginBottom: 0,
@@ -47,18 +44,12 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('md')]: {
       marginTop: 0,
     },
-    [theme.breakpoints.up('lg')]: {
-      marginTop: 0,
-    },
   },
   backButton: {
     [theme.breakpoints.down('sm')]: {
       justifyContent: "center",
     },
     [theme.breakpoints.up('md')]: {
-      justifyContent: "flex-start",
-    },
-    [theme.breakpoints.up('lg')]: {
       justifyContent: "flex-start",
     },
   }
@@ -100,6 +91,7 @@ const NextStepsSuccess = ({ quiz }) => {
           variant="contained"
           href="https://www.surveymonkey.com/r/MYYY7L5"
           target="_blank"
+          rel="noopener noreferrer"
         >
           Share Feedback
         </Button>
@@ -125,6 +117,7 @@ const NextStepsSuccess = ({ quiz }) => {
             variant="contained"
             type="submit"
             target="_blank"
+            rel="noopener noreferrer"
           >
             Make a Contribution
           </Button>

--- a/src/components/pages/NextStepsSuccess.js
+++ b/src/components/pages/NextStepsSuccess.js
@@ -15,6 +15,7 @@ import {
   Button,
   Grid,
   Box,
+  Divider,
   Link as MuiLink,
 } from "@material-ui/core"
 
@@ -22,9 +23,9 @@ import {
 import { Title } from "components/layout"
 
 const NextStepsSuccess = ({ quiz }) => {
-  if (!quiz.agreement) {
-    return <Redirect to="/" />
-  }
+  // if (!quiz.agreement) {
+  //   return <Redirect to="/" />
+  // }
 
   return (
     <Container maxWidth="md">
@@ -32,65 +33,68 @@ const NextStepsSuccess = ({ quiz }) => {
       <Box mb={2}>
         <Typography variant="h1">You're All Set!</Typography>
       </Box>
-      <Box mb={2}>
+      <Box mb={4}>
         <Typography variant="body1">
-          If you don't see an email from compensation@freefrom.org soon, please
-          check your Spam folder.
+          Make sure to add compass@freefrom.org to your address book so you receive our emails.
+          If you don't see an email from us in the next day, please check your Spam folder.
         </Typography>
       </Box>
-      <Box mb={2} mt={4}>
-        <Typography variant="body1">
-          In the meantime, we have a few quick questions about how we can
-          improve this tool. Sharing your feedback will take less than one
-          minute.
-        </Typography>
-        <Box mt={2}>
-          <Grid container item justify="center" alignItems="center">
-            <Button
-              color="primary"
-              variant="contained"
-              href="https://www.surveymonkey.com/r/MYYY7L5"
-              target="_blank"
-            >
-              Share Feedback
-            </Button>
-          </Grid>
+
+      <Divider light={true} />
+
+      <Box display="flex" alignItems="flex-start" justifyContent="space-between" paddingBottom={4} paddingTop={4} >
+        <Box maxWidth={500}>
+          <Typography variant="body1">
+            We have a few quick questions about how we can
+            improve this tool. Sharing your feedback will take less than one
+            minute.
+          </Typography>
         </Box>
+        <Button
+          color="primary"
+          variant="contained"
+          href="https://www.surveymonkey.com/r/MYYY7L5"
+          target="_blank"
+        >
+          Share Feedback
+        </Button>
       </Box>
 
+      <Divider light={true} />
 
-      <Box mb={2}>
-        <Typography variant="body1">
-          Want to help us help other survivors?  Give $1, $3, or $5 so that we
-          can continue to improve the Compensation Compass and help survivors
-          get the compensation they need to stay safe.
-        </Typography>
-
-        <Box mt={3}>
-          <Grid container item justify="center" alignItems="center">
-          <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-            <input type="hidden" name="cmd" value="_s-xclick" />
-            <input type="hidden" name="hosted_button_id" value="PC66QVXYX42RQ" />
-            <Button
-              color="primary"
-              variant="contained"
-              type="submit"
-            >
-              Make a Contribution
-            </Button>
-          </form>
-          </Grid>
+      <Box display="flex" alignItems="flex-start" justifyContent="space-between" paddingTop={4} paddingBottom={4}>
+        <Box maxWidth={500}>
+          <Typography variant="body1">
+            Want to help us help other survivors?  Give $1, $3, or $5 so that we
+            can continue to improve the Compensation Compass and help survivors
+            get the compensation they need to stay safe.
+          </Typography>
         </Box>
+
+        <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+          <input type="hidden" name="cmd" value="_s-xclick" />
+          <input type="hidden" name="hosted_button_id" value="PC66QVXYX42RQ" />
+          <Button
+            color="primary"
+            variant="contained"
+            type="submit"
+            target="_blank"
+          >
+            Make a Contribution
+          </Button>
+        </form>
       </Box>
 
-      <Box mt={5}>
-        <Grid container item justify="center" alignItems="center">
+      <Divider light={true} />
+
+      <Box mt={4}>
+        <Grid container item alignItems="center">
           <Grid item>
             <Button
               color="primary"
               variant="outlined"
               component={Link}
-              to={`/mindsets/${quiz.mindset.slug}/${quiz.location}`}
+              // to={`/mindsets/${quiz.mindset.slug}/${quiz.location}`}
               onClick={scrollToTop}
             >
               Back To Results

--- a/src/components/pages/NextStepsSuccess.js
+++ b/src/components/pages/NextStepsSuccess.js
@@ -16,13 +16,57 @@ import {
   Grid,
   Box,
   Divider,
+  makeStyles,
   Link as MuiLink,
 } from "@material-ui/core"
 
 // Components
 import { Title } from "components/layout"
 
+const useStyles = makeStyles(theme => ({
+  buttonBox: {
+    flexDirection: "row",
+    [theme.breakpoints.down('sm')]: {
+      flexDirection: "column",
+      alignItems: "center",
+      paddingLeft: 10,
+      paddingRight: 10,
+    },
+    [theme.breakpoints.up('md')]: {
+      flexDirection: "row",
+    },
+    [theme.breakpoints.up('lg')]: {
+      flexDirection: "row",
+    },
+  },
+  actionButton: {
+    marginBottom: 0,
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 20,
+    },
+    [theme.breakpoints.up('md')]: {
+      marginTop: 0,
+    },
+    [theme.breakpoints.up('lg')]: {
+      marginTop: 0,
+    },
+  },
+  backButton: {
+    [theme.breakpoints.down('sm')]: {
+      justifyContent: "center",
+    },
+    [theme.breakpoints.up('md')]: {
+      justifyContent: "flex-start",
+    },
+    [theme.breakpoints.up('lg')]: {
+      justifyContent: "flex-start",
+    },
+  }
+}))
+
 const NextStepsSuccess = ({ quiz }) => {
+  const classes = useStyles();
+
   // if (!quiz.agreement) {
   //   return <Redirect to="/" />
   // }
@@ -42,7 +86,7 @@ const NextStepsSuccess = ({ quiz }) => {
 
       <Divider light={true} />
 
-      <Box display="flex" alignItems="flex-start" justifyContent="space-between" paddingBottom={4} paddingTop={4} >
+      <Box className={classes.buttonBox} display="flex" alignItems="flex-start" justifyContent="space-between" paddingBottom={4} paddingTop={4} >
         <Box maxWidth={500}>
           <Typography variant="body1">
             We have a few quick questions about how we can
@@ -51,6 +95,7 @@ const NextStepsSuccess = ({ quiz }) => {
           </Typography>
         </Box>
         <Button
+          className={classes.actionButton}
           color="primary"
           variant="contained"
           href="https://www.surveymonkey.com/r/MYYY7L5"
@@ -62,7 +107,7 @@ const NextStepsSuccess = ({ quiz }) => {
 
       <Divider light={true} />
 
-      <Box display="flex" alignItems="flex-start" justifyContent="space-between" paddingTop={4} paddingBottom={4}>
+      <Box className={classes.buttonBox} display="flex" alignItems="flex-start" justifyContent="space-between" paddingTop={4} paddingBottom={4}>
         <Box maxWidth={500}>
           <Typography variant="body1">
             Want to help us help other survivors?  Give $1, $3, or $5 so that we
@@ -75,6 +120,7 @@ const NextStepsSuccess = ({ quiz }) => {
           <input type="hidden" name="cmd" value="_s-xclick" />
           <input type="hidden" name="hosted_button_id" value="PC66QVXYX42RQ" />
           <Button
+            className={classes.actionButton}
             color="primary"
             variant="contained"
             type="submit"
@@ -88,7 +134,7 @@ const NextStepsSuccess = ({ quiz }) => {
       <Divider light={true} />
 
       <Box mt={4}>
-        <Grid container item alignItems="center">
+        <Grid container item className={classes.backButton}>
           <Grid item>
             <Button
               color="primary"


### PR DESCRIPTION
I'm working with FreeFrom on making sure fewer of the drip campaign emails go to spam. One way to do that is to make sure people add your address to their address book. I added some copy to the Next Steps > Success page asking users to do that, and I did a quick re-design while I was at it because my previous design was terrible :)

Here's the new page:
<img width="1440" alt="Screen Shot 2020-03-13 at 7 10 41 PM" src="https://user-images.githubusercontent.com/9601737/76665889-edd96500-655e-11ea-9373-660b1e745015.png">

And it's responsive!
<img width="1440" alt="Screen Shot 2020-03-13 at 7 10 52 PM" src="https://user-images.githubusercontent.com/9601737/76665909-f03bbf00-655e-11ea-9bb6-387bb08ed057.png">

To test, comment out lines 70-72 and 143 of this file, and then navigate to `localhost:5000/next-steps/success`. 