### PR TITLE
Update aws-s3 CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  aws-s3: circleci/aws-s3@1.0.8
+  aws-s3: circleci/aws-s3@3.0.0
 jobs:
   build:
     docker:


### PR DESCRIPTION
Fix deployments, hopefully? See https://app.circleci.com/pipelines/github/RagtagOpen/freefrom-compensation-web