### PR TITLE
Replace AWS with Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  aws-s3: circleci/aws-s3@3.0.0
+  heroku: circleci/heroku@1.2.6
 jobs:
   build:
     docker:
@@ -31,59 +31,11 @@ jobs:
             yarn run test
 
   deploy:
-    docker:
-      - image: "circleci/node"
+    executor: heroku/default
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
-
-      - run:
-          name: install dependencies
-          command: |
-            yarn install
-
-      - save_cache:
-          paths:
-            - ./node_modules.
-          key: v1-dependencies-{{ checksum "yarn.lock" }}
-
-      - run:
-          name: build React app
-          command: |
-            CI=false yarn run build  # the CI flag here is because react-scripts treats any warning as a failing error during build
-
-      # upload everything
-      - aws-s3/copy:
-          from: ./build/
-          to: "s3://freefrom-compensation-dev"
-          arguments: '--recursive --include="*" --exclude ".circleci*" --exclude ".git*" --exclude "*.json" --exclude "robots.txt" --exclude "index.html" --exclude "service-worker.js" --acl public-read --cache-control max-age=31536000,public'
-
-      # override the cache settings for the root json files and robots.txt
-      - aws-s3/copy:
-          from: ./build/
-          to: "s3://freefrom-compensation-dev"
-          arguments: '--recursive --exclude="*" --include="*.json" --include="robots.txt" --acl public-read --cache-control max-age=60,public'
-
-      # override the cache settings for index.html and service-worker.js
-      - aws-s3/copy:
-          from: ./build/
-          to: "s3://freefrom-compensation-dev"
-          arguments: '--recursive --exclude="*" --include "index.html" --include "service-worker.js" --acl public-read --cache-control max-age=0,private'
-
-      # sync static images
-      - aws-s3/copy:
-          from: ./src/images/
-          to: "s3://freefrom-compensation-dev/images/"
-          arguments: "--recursive --acl public-read --cache-control max-age=3600,public"
-
-      - run:
-          name: Invalidate CloudFront
-          command: |
-            aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/*"
+      - heroku/install
+      - heroku/deploy-via-git
 
 workflows:
   version: 2
@@ -95,4 +47,6 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only:
+                - main
+                - master


### PR DESCRIPTION
This change will make CircleCI deploy to Heroku every time we push to the `main` or `master` branches

We can check https://app.circleci.com/pipelines/github/RagtagOpen/freefrom-compensation-web and https://freefrom-compensation-frontend.herokuapp.com/ after this branch is merged to see if everything worked