### PR TITLE
Set Heroku app name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
     steps:
       - checkout
       - heroku/install
-      - heroku/deploy-via-git
+      - heroku/deploy-via-git:
+          app-name: freefrom-compensation-frontend
 
 workflows:
   version: 2


### PR DESCRIPTION
Pranked myself by forgetting to set the app name and API key

App name is now set to `freefrom-compensation-frontend` in `.circleci/config.yml`

`HEROKU_API_KEY` is now set in https://app.circleci.com/settings/project/github/RagtagOpen/freefrom-compensation-web/environment-variables